### PR TITLE
Change priority

### DIFF
--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -157,8 +157,9 @@ public class RNPushNotificationHelper {
                 title = context.getPackageManager().getApplicationLabel(appInfo).toString();
             }
             NotificationCompat priority;
-            if (bundle.getString("priority")) {
-                switch(bundle.getString("priority").toLowerCase()) {
+            final String priorityString = bundle.getString("priority");
+            if (priorityString != null) {
+                switch(priorityString.toLowerCase()) {
                     case "max":
                         priority = NotficationCompat.PRIORITY_MAX;
                         break;

--- a/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
+++ b/android/src/main/java/com/dieam/reactnativepushnotification/modules/RNPushNotificationHelper.java
@@ -156,12 +156,33 @@ public class RNPushNotificationHelper {
                 ApplicationInfo appInfo = context.getApplicationInfo();
                 title = context.getPackageManager().getApplicationLabel(appInfo).toString();
             }
+            NotificationCompat priority;
+            if (bundle.getString("priority")) {
+                switch(bundle.getString("priority").toLowerCase()) {
+                    case "max":
+                        priority = NotficationCompat.PRIORITY_MAX;
+                        break;
+                    case "high":
+                        priority = NotficationCompat.PRIORITY_HIGH;
+                        break;
+                    case "low":
+                        priority = NotficationCompat.PRIORITY_LOW;
+                        break;
+                    case "min":
+                        priority = NotficationCompat.PRIORITY_MIN;
+                        break;
+                    default:
+                        priority = NotificationCompat.PRIORITY_LOW
+                }
+            } else {
+                priority = NotificationCompat.PRIORITY_LOW;
+            }
 
             NotificationCompat.Builder notification = new NotificationCompat.Builder(context)
                     .setContentTitle(title)
                     .setTicker(bundle.getString("ticker"))
                     .setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
-                    .setPriority(NotificationCompat.PRIORITY_HIGH)
+                    .setPriority(priority)
                     .setAutoCancel(bundle.getBoolean("autoCancel", true));
 
             String group = bundle.getString("group");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datacamp/react-native-push-notification",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "React Native Local and Remote Notifications",
   "main": "index",
   "scripts": {


### PR DESCRIPTION
Issue [#749](https://github.com/datacamp/mobile/issues/749)

In android, daily reminders came through the "only important" setting of "do not disturb". This was because the original priority was set to high in the react-native-push-notification library. So now there is the option to pass the priority, but it isn't mandatory.